### PR TITLE
replace os.SEEK_SET to io.SeekStart

### DIFF
--- a/massivedl_test.go
+++ b/massivedl_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"io"
 	"io/ioutil"
-	"os"
 	"testing"
 )
 
@@ -33,7 +32,7 @@ func TestAskUserBool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = in.Seek(0, os.SEEK_SET)
+	_, err = in.Seek(0, io.SeekStart)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hi! I've just replaced `os.SEEK_SET`(since its [deprecated](https://golang.org/pkg/os/#pkg-constants)) to `io.SeekStart`