### PR TITLE
[FEATURE] Delay parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ massivedl
 .vscode/
 
 bin/
+
+#OSX system folder files 
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ downloads/
 *.log
 massivedl
 .vscode/
+
+bin/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS = " \
 	-X main.Githash=$(GITHASH) \
 "
 
-all: massivedl_linux_amd64 massivedl_win_amd64.exe
+all: massivedl_linux_amd64 massivedl_win_amd64.exe massivedl_darwin_amd64
 
 massivedl_linux_amd64: massivedl.go utilities.go
 	env GOOS=linux GOARCH=amd64 \
@@ -16,3 +16,7 @@ massivedl_linux_amd64: massivedl.go utilities.go
 massivedl_win_amd64.exe: massivedl.go utilities.go
 	env GOOS=windows GOARCH=amd64 \
 		go build -ldflags $(LDFLAGS) -o bin/massivedl_win_amd64.exe
+
+massivedl_darwin_amd64: massivedl.go utilities.go
+	env GOOS=darwin GOARCH=amd64 \
+		go build -ldflags $(LDFLAGS) -o bin/massivedl_darwin_amd64

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Download a large list of files in parallel.
 ```bash
 # for linux 64bit
 wget https://github.com/dimkouv/massivedl/releases/download/v1.2/massivedl_linux_amd64
-chmod +x massivedl_linux_x86_64
-mv massivedl_linux_x86_64 /usr/local/bin/massivedl
+chmod +x massivedl_linux_amd64
+mv massivedl_linux_amd64 /usr/local/bin/massivedl
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Download a large list of files in parallel.
 # for linux 64bit
 wget https://github.com/dimkouv/massivedl/releases/download/v1.0/massivedl_linux_x86_64
 chmod +x massivedl_linux_x86_64
-mv massivedl_linux_x86_64 /bin/massivedl
+mv massivedl_linux_x86_64 /usr/local/bin/massivedl
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Download a large list of files in parallel.
 
 ```bash
 # for linux 64bit
-wget https://github.com/dimkouv/massivedl/releases/download/v1.0/massivedl_linux_x86_64
+wget https://github.com/dimkouv/massivedl/releases/download/v1.1/massivedl_linux_x86_64
 chmod +x massivedl_linux_x86_64
 mv massivedl_linux_x86_64 /usr/local/bin/massivedl
 ```

--- a/README.md
+++ b/README.md
@@ -37,5 +37,20 @@ massivedl -p 10 -i data.csv -s 1 -o downloads
 -o <str> (default='downloads') : Directory to place the downloads
 ```
 
+### Stop and continue later
+You can stop and continue downloading later.  
+Press `Ctrl+C` then you will have the following dialog.
+
+```bash
+...
+Do you want to save progress? [Y/n]: yes
+
+Progress has been saved!
+Use the following command to continue downloading
+
+	massivedl --load /path/to/savedfile.save
+```
+
+
 ## Use Cases
 With this tool I was able to download about 1.5 million images (~60GB) for a machine learning project.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Download a large list of files in parallel.
 
 ```bash
 # for linux 64bit
-wget https://github.com/dimkouv/massivedl/releases/download/v1.1/massivedl_linux_x86_64
+wget https://github.com/dimkouv/massivedl/releases/download/v1.2/massivedl_linux_amd64
 chmod +x massivedl_linux_x86_64
 mv massivedl_linux_x86_64 /usr/local/bin/massivedl
 ```

--- a/examples/list-of-photos.csv
+++ b/examples/list-of-photos.csv
@@ -10,4 +10,4 @@ name,url
 8.png,https://placehold.it/100x108
 9.png,https://placehold.it/100x109
 10.png,https://placehold.it/100x110
-11.png,https://placehold.it/100x111
+sub/sub/dir/11.png,https://placehold.it/100x111

--- a/massivedl.go
+++ b/massivedl.go
@@ -154,7 +154,7 @@ func parseCmdLineParams() CmdLineParams {
 					log.Fatal("Error parsing command line parameters")
 				}
 			} else if strings.Compare(os.Args[i], "-d") == 0 {
-				// -d ::: delay in seconds between each unparallel request
+				// -d ::: delay in seconds between each unparalleled request
 				p.DelayPerRequest, err = strconv.ParseFloat(os.Args[i+1], 64)
 
 				if err != nil || p.DelayPerRequest < 0 {
@@ -193,7 +193,7 @@ func printUsage() {
 		"\t-s <int> (default=0)           ::: Number of skipped lines from input csv",
 		"\t-o <str> (default='downloads') ::: Directory to place the downloads",
 		"\t-r <int> (default=1)           ::: Maximum number of retries for failed downloads",
-		"\t-d <float64> (default=0.0)     ::: Delay (in seconds) between each unparallel request",
+		"\t-d <float64> (default=0.0)     ::: Delay (in seconds) between each unparalleled request",
 		"\nEXAMPLE",
 		"\tmassivedl -p 10 -i data.csv -s 1 -o downloads -d 2.3",
 		"\nAUTHOR",

--- a/massivedl.go
+++ b/massivedl.go
@@ -154,7 +154,7 @@ func parseCmdLineParams() CmdLineParams {
 					log.Fatal("Error parsing command line parameters")
 				}
 			} else if strings.Compare(os.Args[i], "-d") == 0 {
-				// -d ::: delay in seconds between each unparallel request starting time
+				// -d ::: delay in seconds between each unparallel request
 				p.DelayPerRequest, err = strconv.ParseFloat(os.Args[i+1], 64)
 
 				if err != nil || p.DelayPerRequest < 0 {
@@ -195,7 +195,7 @@ func printUsage() {
 		"\t-r <int> (default=1)           ::: Maximum number of retries for failed downloads",
 		"\t-d <float64> (default=0.0)     ::: Delay (in seconds) between each unparallel request",
 		"\nEXAMPLE",
-		"\tmassivedl -p 10 -i data.csv -s 1 -o downloads",
+		"\tmassivedl -p 10 -i data.csv -s 1 -o downloads -d 2.3",
 		"\nAUTHOR",
 		"\tdimkouv <dimkouv@protonmail.com>",
 		"\tContributions at: https://github.com/dimkouv/massivedl",
@@ -424,6 +424,8 @@ func worker(id int, jobs <-chan dataEntry, results chan<- logEntry, statsMutex *
 		updateStatistics(res, statsMutex)
 		writeToLog(res)
 		results <- res
+
+		time.Sleep(floatToDuration(p.DelayPerRequest, "s"))
 	}
 }
 

--- a/massivedl.go
+++ b/massivedl.go
@@ -36,12 +36,13 @@ type dataEntry struct {
 
 // CmdLineParams - Configuration struct
 type CmdLineParams struct {
-	ConcurrentRequests int    `json:"concurrentRequests"`
-	EntriesFilepath    string `json:"entriesFilepath"`
-	SkippedLines       int    `json:"skippedLines"`
-	OutputDir          string `json:"outputDir"`
-	MaxRetries         int    `json:"maxRetries"`
-	Offset             int    `json:"offset"`
+	ConcurrentRequests int     `json:"concurrentRequests"`
+	EntriesFilepath    string  `json:"entriesFilepath"`
+	SkippedLines       int     `json:"skippedLines"`
+	OutputDir          string  `json:"outputDir"`
+	MaxRetries         int     `json:"maxRetries"`
+	Offset             int     `json:"offset"`
+	DelayPerRequest    float64 `json:"delayPerRequest"`
 }
 
 // Statistics - statistics about the downloads
@@ -110,7 +111,7 @@ func parseDownloadsFromCsv(filename string, offset int) []dataEntry {
 }
 
 func parseCmdLineParams() CmdLineParams {
-	p := CmdLineParams{10, "", 0, "downloads", 1, 0}
+	p := CmdLineParams{10, "", 0, "downloads", 1, 0, 0.0}
 	var err error
 
 	if strIndexOf(os.Args, "--help") >= 0 {
@@ -152,6 +153,15 @@ func parseCmdLineParams() CmdLineParams {
 					printUsage()
 					log.Fatal("Error parsing command line parameters")
 				}
+			} else if strings.Compare(os.Args[i], "-d") == 0 {
+				// -d ::: delay in seconds between each unparallel request starting time
+				p.DelayPerRequest, err = strconv.ParseFloat(os.Args[i+1], 64)
+
+				if err != nil || p.DelayPerRequest < 0 {
+					printUsage()
+					log.Fatal("Error parsing command line parameters")
+				}
+
 			}
 		}
 	}
@@ -183,6 +193,7 @@ func printUsage() {
 		"\t-s <int> (default=0)           ::: Number of skipped lines from input csv",
 		"\t-o <str> (default='downloads') ::: Directory to place the downloads",
 		"\t-r <int> (default=1)           ::: Maximum number of retries for failed downloads",
+		"\t-d <float64> (default=0.0)     ::: Delay (in seconds) between each unparallel request",
 		"\nEXAMPLE",
 		"\tmassivedl -p 10 -i data.csv -s 1 -o downloads",
 		"\nAUTHOR",

--- a/utilities.go
+++ b/utilities.go
@@ -86,3 +86,17 @@ func askUserBool(msg string, defaultChoice bool, in *os.File) bool {
 
 	return defaultChoice
 }
+
+//Convert a float64 to time.Duration
+//@param quantity - the quantity of time to convert
+//@param unit - the time unit of conversion ("ns", "us" (or "µs"), "ms", "s", "m", "h")
+func floatToDuration(tQuantity float64, tUnit string) time.Duration {
+	stringTime := fmt.Sprintf("%g", tQuantity) + tUnit
+	duration, err := time.ParseDuration(stringTime)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return duration
+}


### PR DESCRIPTION
**Request**
Add new command line parameter (float) in order to add a delay between each unparalleled request.

**Test**
_Added -d <float64> parameter_

`bin/massivedl_darwin_amd64 -i examples/list-of-photos.csv  -p 3 -d 3.23`

**Results**

```
Start worker:   0        @ time:        2019-02-18 23:56:10.363838 +0100 CET m=+0.002665282
Start worker:   1        @ time:        2019-02-18 23:56:10.363843 +0100 CET m=+0.002670122
Start worker:   2        @ time:        2019-02-18 23:56:10.363844 +0100 CET m=+0.002670947
End worker:     0        @ time:        2019-02-18 23:56:10.364086 +0100 CET m=+0.002912550
End worker:     1        @ time:        2019-02-18 23:56:11.206517 +0100 CET m=+0.845343891
End worker:     2        @ time:        2019-02-18 23:56:11.225468 +0100 CET m=+0.864295183
Start worker:   0        @ time:        2019-02-18 23:56:13.364668 +0100 CET m=+3.003494515
End worker:     0        @ time:        2019-02-18 23:56:13.540199 +0100 CET m=+3.179024860
Start worker:   1        @ time:        2019-02-18 23:56:14.208449 +0100 CET m=+3.847274425
Start worker:   2        @ time:        2019-02-18 23:56:14.225881 +0100 CET m=+3.864706444
End worker:     1        @ time:        2019-02-18 23:56:14.384409 +0100 CET m=+4.023234340
End worker:     2        @ time:        2019-02-18 23:56:14.391765 +0100 CET m=+4.030590814
Start worker:   0        @ time:        2019-02-18 23:56:16.545538 +0100 CET m=+6.184362350
End worker:     0        @ time:        2019-02-18 23:56:16.712658 +0100 CET m=+6.351483093
Start worker:   1        @ time:        2019-02-18 23:56:17.389708 +0100 CET m=+7.028532169
Start worker:   2        @ time:        2019-02-18 23:56:17.392055 +0100 CET m=+7.030879291
End worker:     1        @ time:        2019-02-18 23:56:17.556541 +0100 CET m=+7.195365510
End worker:     2        @ time:        2019-02-18 23:56:17.567903 +0100 CET m=+7.206727542
Start worker:   0        @ time:        2019-02-18 23:56:19.716059 +0100 CET m=+9.354882996
End worker:     0        @ time:        2019-02-18 23:56:19.892904 +0100 CET m=+9.531727622
Start worker:   1        @ time:        2019-02-18 23:56:20.56002 +0100 CET m=+10.198843015
Start worker:   2        @ time:        2019-02-18 23:56:20.568174 +0100 CET m=+10.206997226
End worker:     2        @ time:        2019-02-18 23:56:20.734076 +0100 CET m=+10.372898872
End worker:     1        @ time:        2019-02-18 23:56:20.736285 +0100 CET m=+10.375108014
Start worker:   0        @ time:        2019-02-18 23:56:22.896886 +0100 CET m=+12.535708858
End worker:     0        @ time:        2019-02-18 23:56:23.073548 +0100 CET m=+12.712370041
```
