### PR TITLE
Add support for URLs containing commas

### DIFF
--- a/massivedl.go
+++ b/massivedl.go
@@ -91,7 +91,7 @@ func parseDownloadsFromCsv(filename string, offset int) []dataEntry {
 		scanner.Scan()
 	}
 	for scanner.Scan() {
-		parts := strings.Split(scanner.Text(), ",")
+		parts := strings.SplitN(scanner.Text(), ",", 2)
 		if len(parts) != 2 {
 			continue
 		}


### PR DESCRIPTION
Please let me know if this isn't the preferred way to handle this. For URLs containing commas, the following check fails:

```go
if len(parts) != 2
```

This file, for example, will appear to be empty:

```csv
0.json,https://example.org/resource0?fields=a,b,c
1.json,https://example.org/resource1?fields=a,b,c
```

This is just a quick fix to only split on the first comma.